### PR TITLE
Improve server logging with timestamps

### DIFF
--- a/server/logging_config.py
+++ b/server/logging_config.py
@@ -1,0 +1,13 @@
+import logging
+import sys
+
+logger = logging.getLogger("va_server")
+logger.setLevel(logging.INFO)
+
+handler = logging.StreamHandler(sys.stdout)
+formatter = logging.Formatter("%(asctime)s [%(levelname)s] %(message)s")
+handler.setFormatter(formatter)
+
+if not logger.handlers:
+    logger.addHandler(handler)
+logger.propagate = False


### PR DESCRIPTION
## Summary
- introduce centralized `logging_config` for timestamped server logs
- enhance FastAPI middleware and validation handler to emit detailed logs with request IDs and durations

## Testing
- `pytest` *(fails: async def functions are not natively supported)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ad374db4348320a1e37ac31d5c74e1